### PR TITLE
influxdb tag is wrong, pushed back to 1.4.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - influxdb
   influxdb:
     # Full tag list: https://hub.docker.com/r/library/influxdb/tags/
-    image: influxdb:1.5.0
+    image: influxdb:1.4.3
     volumes:
       # Mount for influxdb data directory
       - ./influxdb/data:/var/lib/influxdb


### PR DESCRIPTION
Unfortunately influx 1.5 seems not available at dockerhub. Hence, I recommend to stick to 1.4.3 (currently latest)