### PR TITLE
moved from Alpine 3.4 to 3.6 to support arm architecture

### DIFF
--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 EXPOSE 3010:3000
 


### PR DESCRIPTION
as the TICK stack is one of the few "official" arm supported images on Docker Hub, this little change enables the sandbox to run on a raspberry pi 3 out of the box.