### PR TITLE
allow to call sandbox from any location

### DIFF
--- a/sandbox
+++ b/sandbox
@@ -157,4 +157,6 @@ EOF
   esac
 }
 
-sandbox $@
+pushd `dirname $0` > /dev/null
+    sandbox $@
+popd > /dev/null


### PR DESCRIPTION
Previously sandbox script included some sources using relative path, e.g.:
source .env-nightlies
Hence, if calling ./sandbox from outside the tick-sandbox directory, sources couldn't be found.
This commit fixes that behaviour by temporarily moving into current sandbox's directory.